### PR TITLE
Get CodePipeline based CICD running

### DIFF
--- a/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -655,7 +655,6 @@ Resources:
 
   # IAM role to be assumed by CloudWatch events service to trigger the CodePipeline
   CodePipelineTriggerRuleRole:
-    Condition: UseCodeCommit
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -46,6 +46,7 @@ Resources:
             Status: Enabled
 
   DeploymentBucketPolicy:
+    Condition: UseCodeCommit
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: ${self:custom.settings.deploymentBucketName}
@@ -270,25 +271,8 @@ Resources:
 
         - Name: Artifact
           Actions:
-            - Name: Submodules
-              RunOrder: 1
-              ActionTypeId:
-                Category: Build
-                Owner: AWS
-                Provider: CodeBuild
-                Version: '1'
-              Configuration:
-                ProjectName: !Ref TargetEnvSubmodulesProject
-              InputArtifacts:
-                - !If
-                  - UseCodeCommit
-                  - Name: SourceCodeCommitArtifact
-                  - Name: SourceGitHubArtifact
-              OutputArtifacts:
-                - Name: SourceSubmoduleArtifact
-
             - Name: Assemble
-              RunOrder: 2
+              RunOrder: 1
               ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -297,7 +281,10 @@ Resources:
               Configuration:
                 ProjectName: !Ref TargetEnvAssembleProject
               InputArtifacts:
-                - Name: SourceSubmoduleArtifact
+                - !If
+                  - UseCodeCommit
+                  - Name: CodeCommitSource
+                  - Name: SourceGitHubArtifact
               OutputArtifacts:
                 - Name: SourceArtifact
 
@@ -408,62 +395,6 @@ Resources:
                   ProjectName: !Ref TestTargetEnvProject
                 InputArtifacts:
                   - Name: SourceArtifact
-          - !Ref AWS::NoValue
-
-  TargetEnvSubmodulesProject:
-    Type: AWS::CodeBuild::Project
-    Properties:
-      Artifacts:
-        Type: CODEPIPELINE
-        ArtifactIdentifier: SourceSubmodulesArtifact
-      Source:
-        Type: CODEPIPELINE
-        BuildSpec: |
-          version: 0.2
-
-          env:
-            git-credential-helper: yes
-
-          phases:
-            install:
-              runtime-versions:
-                nodejs: 14
-
-            build:
-              commands:
-                - echo "Initializing submodules"
-                - git submodule update --init --recursive --jobs=$((`nproc` / 2))
-
-          artifacts:
-            files:
-              - '**/*'
-            name: SourceSubmodulesArtifact
-            discard-paths: no
-
-      Environment:
-        ComputeType: BUILD_GENERAL1_LARGE
-        Type: LINUX_CONTAINER
-        Image: aws/codebuild/standard:5.0
-        EnvironmentVariables:
-          - Name: ENV_NAME
-            Value: ${self:custom.settings.envName}
-          - Name: DEPLOYMENT_BUCKET
-            Value: ${self:custom.settings.deploymentBucketName}
-      ServiceRole: !GetAtt AppPipelineRole.Arn
-      Cache:
-        # Use local caching to cache dirs specified in buildspec.yml (i.e., the node_modules dirs)
-        # See https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html for various build caching options
-        Type: LOCAL
-        Modes:
-          - LOCAL_SOURCE_CACHE
-          - LOCAL_CUSTOM_CACHE
-      VpcConfig:
-        !If 
-          - UseVpc 
-          - 
-            VpcId: ${self:custom.settings.codeBuildVpcConfig.vpcId}
-            Subnets: ${self:custom.settings.codeBuildVpcConfig.subnets}
-            SecurityGroupIds: ${self:custom.settings.codeBuildVpcConfig.securityGroupIds}
           - !Ref AWS::NoValue
 
   TargetEnvAssembleProject:
@@ -744,6 +675,7 @@ Resources:
                 Resource: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${AppPipeline}'
 
   CodeCommitTriggerPipelineEventRule:
+    Condition: UseCodeCommit
     Type: AWS::Events::Rule
     Properties:
       Name: ${self:custom.settings.namespace}-codecommit-trigger-codepipeline

--- a/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/config/settings/.defaults.yml
+++ b/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/config/settings/.defaults.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-sourceCicdAppArtifactBucketName: ${self:custom.settings.globalNamespace}-cicd-appartifacts
+sourceCicdAppArtifactBucketName: ${self:custom.settings.globalNamespace}-cicd-pipeline-appartifacts
 
 # Flag indicating whether to create a staging environment.
 # If this flag is set to true the pipeline will first deploy the solution to a staging environment before deploying the

--- a/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/serverless.yml
+++ b/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-pipeline/serverless.yml
@@ -23,6 +23,7 @@ provider:
   deploymentBucket:
     name: ${self:custom.settings.deploymentBucketName}
     serverSideEncryption: AES256
+    blockPublicAccess: true
   stackTags: ${self:custom.tags}
   # All references beginning with ${self:*, ${opt:*, ${file:*, ${deep:*, and ${cf:* will be resolved by Serverless
   # All other ${* references will be resolved by CloudFormation

--- a/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-target/config/settings/.defaults.yml
+++ b/components/base-cicd/packages/assembly/assets/deployables/cicd/cicd-target/config/settings/.defaults.yml
@@ -52,5 +52,5 @@ runTestsAgainstTargetEnv: true
 # This setting is ignored when createStagingEnv is not true.
 stgEnvName: ${self:custom.settings.envName}stg
 
-cicdAppArtifactBucketName: ${self:custom.settings.globalNamespace}-cicd-appartifacts
-sourceCicdAppArtifactBucketName: ${self:custom.settings.sourceAccountId}-${self:custom.settings.namespace}-cicd-appartifacts
+cicdAppArtifactBucketName: ${self:custom.settings.globalNamespace}-cicd-target-appartifacts
+sourceCicdAppArtifactBucketName: ${self:custom.settings.sourceAccountId}-${self:custom.settings.namespace}-cicd-pipeline-appartifacts

--- a/components/vam-silky-smooth-deployments/packages/assembly/assets/overrides/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/components/vam-silky-smooth-deployments/packages/assembly/assets/overrides/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -157,24 +157,6 @@ Resources:
               OutputArtifacts:
                 - Name: LicenseS3Artifact
               InputArtifacts: []
-        - Name: Artifact
-          Actions:
-            - Name: Submodules
-              RunOrder: 1
-              ActionTypeId:
-                Category: Build
-                Owner: AWS
-                Provider: CodeBuild
-                Version: '1'
-              Configuration:
-                ProjectName: !Ref TargetEnvSubmodulesProject
-              InputArtifacts:
-                - !If
-                  - UseCodeCommit
-                  - Name: SourceCodeCommitArtifact
-                  - Name: SourceGitHubArtifact
-              OutputArtifacts:
-                - Name: SourceSubmoduleArtifact
         - Name: 'Generate-Deployment-Package'
           Actions:
             - Name: 'Generate-Package'
@@ -186,9 +168,15 @@ Resources:
                 Version: '1'
               Configuration:
                 ProjectName: !Ref 'DeployPackageGenProject'
-                PrimarySource: 'SourceSubmoduleArtifact'
+                PrimarySource: !If
+                  - UseCodeCommit
+                  - 'SourceCodecommitArtifact'
+                  - 'SourceGitHubArtifact'
               InputArtifacts:
-                - Name: 'SourceSubmoduleArtifact'
+                - !If 
+                  - UseCodeCommit
+                  - Name: SourceCodeCommitArtifact
+                  - Name: SourceGitHubArtifact
                 - Name: 'EEProdScriptsArtifact'
                 - Name: 'LicenseS3Artifact'
               OutputArtifacts:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- removes references to git-submodules which the project does not use
- allows cicd-pipeline to reside in the same account as cicd-target

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
