### PR TITLE
add missing cross-region stack values

### DIFF
--- a/components/vam-api/packages/assembly/assets/overrides/edge-lambda/config/settings/.defaults.yml
+++ b/components/vam-api/packages/assembly/assets/overrides/edge-lambda/config/settings/.defaults.yml
@@ -18,3 +18,15 @@ installerHostWorkDomain: ${cf:${self:custom.settings.imageBuilderStackName}.Inst
 installerHostWorkRegionalDomain: ${cf:${self:custom.settings.imageBuilderStackName}.InstallerHostWorkBucketRegionalDomain}
 
 otherImgSrc: '${self:custom.settings.applicationRepoDomain} ${self:custom.settings.applicationRepoRegionalDomain} ${self:custom.settings.installerHostWorkDomain} ${self:custom.settings.installerHostWorkRegionalDomain}'
+
+crossRegionCloudFormation:
+  backendStackName:
+    - settingName: applicationRepoDomain
+      outputKey: ApplicationRepoBucketDomain
+    - settingName: applicationRepoRegionalDomain
+      outputKey: ApplicationRepoBucketRegionalDomain
+  imageBuilderStackName:
+    - settingName: installerHostWorkDomain
+      outputKey: InstallerHostWorkBucketDomain
+    - settingName: installerHostWorkRegionalDomain
+      outputKey: InstallerHostWorkBucketRegionalDomain


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
small fix to clean up an issue deploying outside of us-east-1.
The solution always deploys an edge-lambda stack to us-east-1 regardless of region where other collateral is deployed. Because of this, any values imported by the edge-lambda components from other stacks must be declared somewhat differently than normal serverless syntax to avoid a check for the stacks in the incorrect region. An issue existed where certain values imported from the image-builder and backend cloud formation stacks were not properly declared and caused deployment failures when these stacks were sought by serverless in us-east-1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
