### PR TITLE
add behavior for /docs to cloudfront

### DIFF
--- a/components/base-ui-public-hosting/packages/assembly/assets/overrides/web-infra/config/infra/cloudformation.yml
+++ b/components/base-ui-public-hosting/packages/assembly/assets/overrides/web-infra/config/infra/cloudformation.yml
@@ -199,6 +199,22 @@ Resources:
               Forward: none
           ViewerProtocolPolicy: redirect-to-https
         CacheBehaviors:
+          # Route to DocsSiteBucket for docs requests only
+          - PathPattern: 'docs'
+            DefaultTTL: 0
+            MinTTL: 0
+            MaxTTL: 0
+            AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            Compress: true
+            TargetOriginId: DocsSiteBucketOrigin
+            ForwardedValues:
+              QueryString: true
+              Cookies:
+                Forward: none
+            ViewerProtocolPolicy: redirect-to-https
           # Route to DocsSiteBucket on docs/* requests only
           - PathPattern: 'docs/*'
             DefaultTTL: 0

--- a/components/base-ui-public-hosting/packages/post-deployment-steps/lib/steps/create-cloudfront-interceptor.js
+++ b/components/base-ui-public-hosting/packages/post-deployment-steps/lib/steps/create-cloudfront-interceptor.js
@@ -44,6 +44,8 @@ class CreateCloudFrontInterceptor extends Service {
       { lambdaArn: this.settings.get('securityEdgeLambdaArn'), behavior: 'default', eventType: 'origin-response' },
       { lambdaArn: this.settings.get('securityEdgeLambdaArn'), behavior: 'docs/*', eventType: 'origin-response' },
       { lambdaArn: this.settings.get('redirectsEdgeLambdaArn'), behavior: 'docs/*', eventType: 'origin-request' },
+      { lambdaArn: this.settings.get('securityEdgeLambdaArn'), behavior: 'docs', eventType: 'origin-response' },
+      { lambdaArn: this.settings.get('redirectsEdgeLambdaArn'), behavior: 'docs', eventType: 'origin-request' },
     ];
 
     let didPublishLambdaVersion;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a behavior and appropriate configuration to cloudfront interceptor for edge-lambda to redirect request for /docs to /docs/.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
