### PR TITLE
Add logging bucket dependency

### DIFF
--- a/components/base-ui/packages/assembly/assets/deployables/web-infra/config/infra/cloudformation.yml
+++ b/components/base-ui/packages/assembly/assets/deployables/web-infra/config/infra/cloudformation.yml
@@ -100,6 +100,7 @@ Resources:
   # S3 Bucket for the solution static website
   WebsiteBucket:
     Type: AWS::S3::Bucket
+    DependsOn: [LoggingBucket]
     Properties:
       BucketName: ${self:custom.settings.websiteBucketName}
       BucketEncryption:
@@ -159,6 +160,7 @@ Resources:
   # S3 Bucket for the documentation website
   DocsSiteBucket:
     Type: AWS::S3::Bucket
+    DependsOn: [LoggingBucket]
     Properties:
       BucketName: ${self:custom.settings.docsSiteBucketName}
       BucketEncryption:


### PR DESCRIPTION
*Issue #, if available:*
During a clean deployment, there is a possibility that WebsiteBucket or DocSiteBucket could be deployed before LoggingBucket causing a logging error since the logging bucket has not yet been created.
*Description of changes:*
Link dependency to the LoggingBucket which allows CloudFormation to deploy LoggingBucket before WebsiteBucket or DocSiteBucket is deployed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
