### PR TITLE
Cleanup Image deletion

### DIFF
--- a/components/base/packages/services/lib/s3-service.js
+++ b/components/base/packages/services/lib/s3-service.js
@@ -230,6 +230,27 @@ class S3Service extends Service {
     const result = await this.api.getObject({ Bucket: bucket, Key: key }).promise();
     return result.Body.toString(encoding);
   }
+
+  async deleteObjectsWithPrefix({ bucket, prefix }) {
+    if (!_.isString(prefix)) {
+      // If a prefix is not provided to listObjects it retrieves everything in the bucket.
+      // This protects against accidental deletion of all objects in a bucket.
+      throw new Error('A prefix must be provided');
+    }
+
+    const objects = await this.listObjects({ bucket, prefix });
+    const params = {
+      Bucket: bucket,
+      Delete: {
+        Objects: objects.map(o => {
+          return { Key: o.key };
+        }),
+        Quiet: false,
+      },
+    };
+
+    return this.api.deleteObjects(params).promise();
+  }
 }
 
 export default S3Service;

--- a/components/vam-api/packages/vam-services/lib/appstream/appstream-service.js
+++ b/components/vam-api/packages/vam-services/lib/appstream/appstream-service.js
@@ -516,7 +516,9 @@ class AppstreamService extends Service {
       await appstream.deleteImage({ Name: imageName }).promise();
     } catch (e) {
       // If the image simply couldn't be found continue with the deletion process.
-      if (e.code !== 'ResourceNotFoundException') {
+      // As the API handler role has very limited scope, treat AccessDenied as ResourceNotFound
+      // If an error occurs in image creation, the role will not be able to list all images to verify
+      if (e.code !== 'ResourceNotFoundException' && e.code !== 'AccessDeniedException') {
         const safe = e.code === 'ResourceInUseException';
         throw this.boom.badRequest(e.message, safe);
       }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A bit of cleanup in image deletion
- Allow deleteImage to succeed on "AccessDeniedException" from AppStream
  - Because the API Handler IAM Role has limited access to only those images created by the solution, an attempt to delete an image which was never created will return "AccessDeniedException" assuming it is just an image the IAM role lacks rights to list.
  - bailing out at this point causes the workflow and the application objects in the installer-work S3 bucket to remain.
- Add "deleteObjectsWithPrefix" to the S3 service
  - this was available in an older version of the code base and never made it over in a transition
  - used in deleteImage to remove temporary application objects copied to the installer-work S3 bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
